### PR TITLE
Feat: Rainfall Module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^0.0.8",
         "@nestjs/common": "^8.0.0",
         "@nestjs/config": "^2.1.0",
         "@nestjs/core": "^8.0.0",
@@ -1383,6 +1384,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@nestjs/axios": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.8.tgz",
+      "integrity": "sha512-oJyfR9/h9tVk776il0829xyj3b2e81yTu6HjPraxynwNtMNGqZBHHmAQL24yMB3tVbBM0RvG3eUXH8+pRCGwlg==",
+      "dependencies": {
+        "axios": "0.27.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -9836,6 +9850,14 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@nestjs/axios": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.8.tgz",
+      "integrity": "sha512-oJyfR9/h9tVk776il0829xyj3b2e81yTu6HjPraxynwNtMNGqZBHHmAQL24yMB3tVbBM0RvG3eUXH8+pRCGwlg==",
+      "requires": {
+        "axios": "0.27.2"
       }
     },
     "@nestjs/cli": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^0.0.8",
     "@nestjs/common": "^8.0.0",
     "@nestjs/config": "^2.1.0",
     "@nestjs/core": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,9 +4,14 @@ import { APP_PIPE } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { OpenApiConfigModule } from './config/open-api/config.module';
+import { RainfallModule } from './rainfall/rainfall.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), OpenApiConfigModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    OpenApiConfigModule,
+    RainfallModule,
+  ],
   controllers: [AppController],
   providers: [
     AppService,

--- a/src/config/open-api/config.module.ts
+++ b/src/config/open-api/config.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { OpenApiConfigService } from './config.service';
 
 @Module({
+  imports: [ConfigModule.forRoot()],
   providers: [ConfigService, OpenApiConfigService],
   exports: [ConfigService, OpenApiConfigService],
 })

--- a/src/config/open-api/config.service.spec.ts
+++ b/src/config/open-api/config.service.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OpenApiConfigModule } from './config.module';
+import { OpenApiConfigService } from './config.service';
+
+describe('OpenApiConfigService', () => {
+  let service: OpenApiConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [OpenApiConfigModule],
+    }).compile();
+
+    service = module.get<OpenApiConfigService>(OpenApiConfigService);
+  });
+
+  test('OPEN_API_KEY를 잘 가져오는가 리턴하는가', async () => {
+    // given
+
+    // when
+    const key = service.apiKey;
+
+    // then
+    expect(key).toBeDefined();
+  });
+});

--- a/src/rainfall/dto/get-rainfall-infos.ts
+++ b/src/rainfall/dto/get-rainfall-infos.ts
@@ -1,0 +1,7 @@
+import { RainFallInfo } from './rainfall-info.dto';
+
+export class GetRainFallInfos {
+  list_total_count: number;
+
+  data: [RainFallInfo];
+}

--- a/src/rainfall/dto/get-rainfall-infos.ts
+++ b/src/rainfall/dto/get-rainfall-infos.ts
@@ -1,7 +1,21 @@
-import { RainFallInfo } from './rainfall-info.dto';
+import { RainfallInfo } from './rainfall-info.dto';
+import { RainfallInfosOpenAPI } from './rainfall-infos-openapi';
 
-export class GetRainFallInfos {
+export class GetRainfallInfos {
   list_total_count: number;
 
-  data: [RainFallInfo];
+  data: RainfallInfo[];
+
+  static of(totalCount: number, rainfallInfosOpenAPIs: RainfallInfosOpenAPI[]) {
+    const getRainfallInfos = new GetRainfallInfos();
+    getRainfallInfos.list_total_count = totalCount;
+    getRainfallInfos.data = rainfallInfosOpenAPIs.reduce<RainfallInfo[]>(
+      (prev, cur) => {
+        return [...prev, ...cur.ListRainfallService.row];
+      },
+      [],
+    );
+
+    return getRainfallInfos;
+  }
 }

--- a/src/rainfall/dto/rainfall-info.dto.ts
+++ b/src/rainfall/dto/rainfall-info.dto.ts
@@ -1,0 +1,8 @@
+export class RainFallInfo {
+  RAINGAUGE_CODE: number;
+  RAINGAUGE_NAME: string;
+  GU_CODE: number;
+  GU_NAME: string;
+  RAINFALL10: number;
+  RECEIVE_TIME: Date;
+}

--- a/src/rainfall/dto/rainfall-info.dto.ts
+++ b/src/rainfall/dto/rainfall-info.dto.ts
@@ -1,4 +1,4 @@
-export class RainFallInfo {
+export class RainfallInfo {
   RAINGAUGE_CODE: number;
   RAINGAUGE_NAME: string;
   GU_CODE: number;

--- a/src/rainfall/dto/rainfall-infos-openapi.ts
+++ b/src/rainfall/dto/rainfall-infos-openapi.ts
@@ -1,6 +1,6 @@
-import { RainFallInfo } from './rainfall-info.dto';
+import { RainfallInfo } from './rainfall-info.dto';
 
-export class RainFallInfosOpenAPI {
+export class RainfallInfosOpenAPI {
   ListRainfallService: {
     list_total_count: number;
 
@@ -9,6 +9,6 @@ export class RainFallInfosOpenAPI {
       MESSAGE: string;
     };
 
-    row: [RainFallInfo];
+    row: RainfallInfo[];
   };
 }

--- a/src/rainfall/dto/rainfall-infos-openapi.ts
+++ b/src/rainfall/dto/rainfall-infos-openapi.ts
@@ -1,0 +1,14 @@
+import { RainFallInfo } from './rainfall-info.dto';
+
+export class RainFallInfosOpenAPI {
+  ListRainfallService: {
+    list_total_count: number;
+
+    RESULT: {
+      CODE: string;
+      MESSAGE: string;
+    };
+
+    row: [RainFallInfo];
+  };
+}

--- a/src/rainfall/rainfall.controller.ts
+++ b/src/rainfall/rainfall.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { RainfallService } from './rainfall.service';
+
+@Controller('/rainfall')
+export class RainfallController {
+  constructor(private readonly rainfallService: RainfallService) {}
+
+  @Get()
+  getRainfallInfos(@Query('guName') guName: string) {
+    return this.rainfallService.getRainfallInfos(guName);
+  }
+}

--- a/src/rainfall/rainfall.module.ts
+++ b/src/rainfall/rainfall.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { RainfallService } from './rainfall.service';
+
+@Module({
+  providers: [RainfallService]
+})
+export class RainfallModule {}

--- a/src/rainfall/rainfall.module.ts
+++ b/src/rainfall/rainfall.module.ts
@@ -1,6 +1,7 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { OpenApiConfigModule } from 'src/config/open-api/config.module';
+import { RainfallController } from './rainfall.controller';
 import { RainfallService } from './rainfall.service';
 
 @Module({
@@ -8,6 +9,7 @@ import { RainfallService } from './rainfall.service';
     OpenApiConfigModule,
     HttpModule.register({ baseURL: 'http://openAPI.seoul.go.kr:8088' }),
   ],
+  controllers: [RainfallController],
   providers: [RainfallService],
   exports: [RainfallService],
 })

--- a/src/rainfall/rainfall.module.ts
+++ b/src/rainfall/rainfall.module.ts
@@ -1,7 +1,14 @@
+import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
+import { OpenApiConfigModule } from 'src/config/open-api/config.module';
 import { RainfallService } from './rainfall.service';
 
 @Module({
-  providers: [RainfallService]
+  imports: [
+    OpenApiConfigModule,
+    HttpModule.register({ baseURL: 'http://openAPI.seoul.go.kr:8088' }),
+  ],
+  providers: [RainfallService],
+  exports: [RainfallService],
 })
 export class RainfallModule {}

--- a/src/rainfall/rainfall.service.spec.ts
+++ b/src/rainfall/rainfall.service.spec.ts
@@ -1,4 +1,6 @@
+import { HttpModule } from '@nestjs/axios';
 import { Test, TestingModule } from '@nestjs/testing';
+import { OpenApiConfigModule } from '../config/open-api/config.module';
 import { RainfallService } from './rainfall.service';
 
 describe('RainfallService', () => {
@@ -6,13 +8,27 @@ describe('RainfallService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        OpenApiConfigModule,
+        HttpModule.register({ baseURL: 'http://openAPI.seoul.go.kr:8088' }),
+      ],
       providers: [RainfallService],
     }).compile();
 
     service = module.get<RainfallService>(RainfallService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('getTotalCount', () => {
+    test('해당 지역구의 전체 개수를 리턴하는가', async () => {
+      // given
+      const guName = '강남구';
+
+      // when
+
+      const result = service['getTotalCount'](guName);
+
+      // then
+      await expect(result).resolves.toEqual(expect.any(Number));
+    });
   });
 });

--- a/src/rainfall/rainfall.service.spec.ts
+++ b/src/rainfall/rainfall.service.spec.ts
@@ -44,4 +44,19 @@ describe('RainfallService', () => {
       expect(result.data).toHaveLength(result.list_total_count);
     });
   });
+
+  // TODO: console.log 제거
+  describe('get', () => {
+    test('get Test', async () => {
+      // given
+      const start = 1;
+      const end = 20;
+      const guName = '강남구';
+      // when
+      const result = await service['get'](start, end, guName);
+
+      // then
+      console.log(result);
+    });
+  });
 });

--- a/src/rainfall/rainfall.service.spec.ts
+++ b/src/rainfall/rainfall.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RainfallService } from './rainfall.service';
+
+describe('RainfallService', () => {
+  let service: RainfallService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RainfallService],
+    }).compile();
+
+    service = module.get<RainfallService>(RainfallService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/rainfall/rainfall.service.spec.ts
+++ b/src/rainfall/rainfall.service.spec.ts
@@ -24,11 +24,24 @@ describe('RainfallService', () => {
       const guName = '강남구';
 
       // when
-
       const result = service['getTotalCount'](guName);
 
       // then
       await expect(result).resolves.toEqual(expect.any(Number));
+    });
+  });
+
+  describe('getRainfallInfos', () => {
+    test('해당하는 지역구의 모든 강우량을 가져오는가', async () => {
+      // given
+      const guName = '강남구';
+      // when
+      const result = await service.getRainfallInfos(guName);
+
+      //then
+      expect(result).toBeDefined();
+      expect(result.list_total_count).toEqual(expect.any(Number));
+      expect(result.data).toHaveLength(result.list_total_count);
     });
   });
 });

--- a/src/rainfall/rainfall.service.ts
+++ b/src/rainfall/rainfall.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class RainfallService {}

--- a/src/rainfall/rainfall.service.ts
+++ b/src/rainfall/rainfall.service.ts
@@ -2,7 +2,8 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { map, lastValueFrom } from 'rxjs';
 import { OpenApiConfigService } from '../config/open-api/config.service';
-import { RainFallInfosOpenAPI } from './dto/rainfall-infos-openapi';
+import { GetRainfallInfos } from './dto/get-rainfall-infos';
+import { RainfallInfosOpenAPI } from './dto/rainfall-infos-openapi';
 
 @Injectable()
 export class RainfallService {
@@ -11,15 +12,50 @@ export class RainfallService {
     private readonly httpService: HttpService,
   ) {}
 
+  async getRainfallInfos(guName: string) {
+    const totalCount = await this.getTotalCount(guName);
+
+    const results = await this.getRainfallInfosOpenAPI(totalCount, guName);
+
+    const getRainfallInfos = GetRainfallInfos.of(totalCount, results);
+
+    return getRainfallInfos;
+  }
+
   private async getTotalCount(guName: string) {
-    const response = this.httpService.get<RainFallInfosOpenAPI>(
+    const response = await this.get(1, 1, guName);
+
+    return response.ListRainfallService.list_total_count;
+  }
+
+  private getRainfallInfosOpenAPI(
+    totalCount: number,
+    guName: string,
+  ): Promise<RainfallInfosOpenAPI[]> {
+    const requests: Promise<RainfallInfosOpenAPI>[] = [];
+
+    const requestCount = Math.floor(totalCount / 1000);
+
+    for (let i = 0; i < requestCount; i++) {
+      requests.push(this.get(i * 1000 + 1, (i + 1) * 1000, guName));
+    }
+
+    if (totalCount > requestCount * 1000) {
+      requests.push(this.get(requestCount * 1000 + 1, totalCount, guName));
+    }
+
+    return Promise.all(requests);
+  }
+
+  private async get(start: number, end: number, guName: string) {
+    const response = this.httpService.get<RainfallInfosOpenAPI>(
       encodeURI(
-        `/${this.opanApiConfigService.apiKey}/json/ListRainfallService/1/1/${guName}`,
+        `/${this.opanApiConfigService.apiKey}/json/ListRainfallService/${start}/${end}/${guName}`,
       ),
     );
 
     const result = await lastValueFrom(response.pipe(map((res) => res.data)));
 
-    return result.ListRainfallService.list_total_count;
+    return result;
   }
 }

--- a/src/rainfall/rainfall.service.ts
+++ b/src/rainfall/rainfall.service.ts
@@ -1,4 +1,25 @@
+import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
+import { map, lastValueFrom } from 'rxjs';
+import { OpenApiConfigService } from '../config/open-api/config.service';
+import { RainFallInfosOpenAPI } from './dto/rainfall-infos-openapi';
 
 @Injectable()
-export class RainfallService {}
+export class RainfallService {
+  constructor(
+    private readonly opanApiConfigService: OpenApiConfigService,
+    private readonly httpService: HttpService,
+  ) {}
+
+  private async getTotalCount(guName: string) {
+    const response = this.httpService.get<RainFallInfosOpenAPI>(
+      encodeURI(
+        `/${this.opanApiConfigService.apiKey}/json/ListRainfallService/1/1/${guName}`,
+      ),
+    );
+
+    const result = await lastValueFrom(response.pipe(map((res) => res.data)));
+
+    return result.ListRainfallService.list_total_count;
+  }
+}


### PR DESCRIPTION
1. RainfallService 제작
> `get`: openAPI 요청
> `getTotalCount`: 해당 지역구 강우량 총 개수 조회
> `getRainfallInfosOpenAPI`: 지역구내에 총 강우량 내역 조회
> `getRainfallInfos`: 지역구내에 총 강우량을 조회해 `GetRainfallInfos` dto로 변환

2. GetRainfallInfos, RainfallInfo, RainfallInfosOpenApi 제작
> `GetRainfallInfos`: `getRainfallInfos`의 리턴 값
> `RainfallInfosOpenAPI`: openAPI요청의 응답 값

3. 응답 테스트용 RainfallController , test 추가
> `http://localhost:3000/rainfall?guName=강남구` 로 `getRainfallInfos` 리턴값 확인가능
> 아니면 `rainfall.service.spec.ts` 파일에 `get` 테스트를 통해 openAPI응닶값 확인가능
